### PR TITLE
Add score while Mario is running (still alive)

### DIFF
--- a/Mario-Run/index.html
+++ b/Mario-Run/index.html
@@ -10,6 +10,12 @@
 
 <body>
     <div id="game">
+        <div id="score-wrapper">
+            <h5>Highest:</h5>
+            <h5 id="highest-score">0</h5>
+            <h5>Score:</h5>
+            <h5 id="score">0</h5>
+        </div>
         <div id="character"></div>
         <div id="block"></div>
     </div>

--- a/Mario-Run/script.js
+++ b/Mario-Run/script.js
@@ -1,5 +1,11 @@
 var character = document.getElementById("character");
 var block = document.getElementById("block");
+var highestScore = document.getElementById('highest-score');
+var score = document.getElementById('score');
+var highestScorePoint = Number(localStorage.getItem('mario-highest-score')) || 0;
+var currentPoint = 0;
+
+checkHighestScore();
 
 function jump() {
     if (character.classList != "animate") {
@@ -12,6 +18,11 @@ function jump() {
     }, 1000);
 }
 
+var incrementScore = setInterval(function () {
+    currentPoint++;
+    score.innerHTML = currentPoint;
+}, 100);
+
 var checkLost = setInterval(function () {
     var characterTop =
         parseInt(window.getComputedStyle(character).getPropertyValue("top"));
@@ -23,5 +34,19 @@ var checkLost = setInterval(function () {
         block.style.animation = "none";
         block.style.display = "none";
         alert("Your Lose -GameOver.");
+        clearInterval(incrementScore);
+        checkNewRecord();
     }
 }, 10);
+
+function checkHighestScore () {
+    if (highestScore) {
+        highestScore.innerHTML = highestScorePoint;
+    }
+}
+
+function checkNewRecord () {
+    if (currentPoint > highestScorePoint) {
+        localStorage.setItem('mario-highest-score', currentPoint);
+    }
+}

--- a/Mario-Run/style.css
+++ b/Mario-Run/style.css
@@ -8,6 +8,25 @@
      width: 1360px;
      height: 350px;
      border: 1px solid black;   
+     position: relative;
+}
+
+#score-wrapper {
+    position: absolute;
+    right: 20px;
+    top: 8px;
+    display: grid;
+    grid-template-columns: auto auto;
+    gap: 4px 8px;
+    font-size: 16px;
+}
+
+#highest-score {
+    justify-self: end;
+}
+
+#score {
+    justify-self: end;
 }
 
 #character{


### PR DESCRIPTION
Based on Issue https://github.com/Abhijay007/Mario-Run/issues/1
- Add feature scoring and highest score (on right top)
- Score will stop incrementing when user is lose
- If user's browser has highest score (based on localStorage), will display it on initial load

Final result will be:
<img width="1417" alt="Screen Shot 2020-10-12 at 14 01 54" src="https://user-images.githubusercontent.com/29223530/95715202-a69d8900-0c93-11eb-849a-63a3ff77f01c.png">
